### PR TITLE
Don't use ES6 object shorthand syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@
  const json = require('./lib/json')
 
  module.exports = {
-   alg,
-   Graph,
-   json
+   alg: alg,
+   Graph: Graph,
+   json: json
  }


### PR DESCRIPTION
**This project uses [semver](http://semver.org), please check the scope of this pr:**

- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
Don't use ES6 object shorthand syntax
